### PR TITLE
Update make.ts

### DIFF
--- a/packages/cli/src/commands/make.ts
+++ b/packages/cli/src/commands/make.ts
@@ -60,10 +60,7 @@ makeCommand
       promptsIntro()
     }
     if (name === '.') {
-      updatedName = {
-        name: basename(cwd()),
-        path: cwd(),
-      }
+      updatedName = basename(cwd())
     }
     const projectName = updatedName ? updatedName : undefined
     bedframePrompts(projectName, options).then(async (response) => {


### PR DESCRIPTION
name is sent to `formatTargetDir` later so will be formatted as object then, otherwise it raises an error (for me at least, on Windows)
see:  https://github.com/nyaggah/bedframe/issues/453