### PR TITLE
fix(cli): project gen name/path formatting

### DIFF
--- a/.changeset/afraid-chairs-double.md
+++ b/.changeset/afraid-chairs-double.md
@@ -1,0 +1,9 @@
+---
+'@bedframe/cli': patch
+---
+
+project gen name/path formatting
+
+ensure the different possible project name variations passed into prompts (args and options) are formatted correctly
+
+fixes #453

--- a/package.json
+++ b/package.json
@@ -71,5 +71,6 @@
   "bugs": {
     "url": "https://github.com/nyaggah/bedframe/issues"
   },
-  "homepage": "https://bedframe.dev"
+  "homepage": "https://bedframe.dev",
+  "packageManager": "pnpm@9.1.2+sha512.127dc83b9ea10c32be65d22a8efb4a65fb952e8fefbdfded39bdc3c97efc32d31b48b00420df2c1187ace28c921c902f0cb5a134a4d032b8b5295cbfa2c681e2"
 }

--- a/packages/cli/src/commands/make.ts
+++ b/packages/cli/src/commands/make.ts
@@ -1,4 +1,4 @@
-import { basename } from 'node:path'
+import { basename, resolve } from 'node:path'
 import { cwd } from 'node:process'
 import { Command } from 'commander'
 import { dim } from 'kolorist'
@@ -55,7 +55,7 @@ makeCommand
   )
 
   .action((name, options) => {
-    let updatedName = name
+    let updatedName: { name: string; path: string } | undefined
     if (options) {
       promptsIntro()
     }
@@ -65,7 +65,14 @@ makeCommand
         path: cwd(),
       }
     }
+    if (name) {
+      updatedName = {
+        name: basename(name),
+        path: resolve(name),
+      }
+    }
     const projectName = updatedName ? updatedName : undefined
+
     bedframePrompts(projectName, options).then(async (response) => {
       await makeBed(response).catch(console.error)
     })

--- a/packages/cli/src/lib/make/prompts/prompts-utils.ts
+++ b/packages/cli/src/lib/make/prompts/prompts-utils.ts
@@ -140,12 +140,3 @@ export const stylingOptions = Object.values(Style).map((style) => {
     value: _style,
   }
 })
-
-export function formatTargetDir(
-  value: string,
-): Record<'name' | 'path', string> {
-  return {
-    name: path.basename(value),
-    path: path.resolve(value),
-  }
-}

--- a/packages/cli/src/lib/make/utils/write-package-json.ts
+++ b/packages/cli/src/lib/make/utils/write-package-json.ts
@@ -92,7 +92,7 @@ export function writePackageJson(response: prompts.Answers<string>): void {
     }
   },
   "devDependencies": {
-    "@bedframe/cli": "0.0.79",
+    "@bedframe/cli": "0.0.80",
     "@bedframe/core": "0.0.43",
 ${
   changesets
@@ -101,16 +101,16 @@ ${
     "@commitlint/config-conventional": "^19.1.0",`
     : ''
 }${
-  hasTests
-    ? `\n"@testing-library/jest-dom": "^6.4.2",
+    hasTests
+      ? `\n"@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.2",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.12",
     "happy-dom": "^14.3.6",
     "vitest": "^1.4.0",
     "@vitest/coverage-istanbul": "^1.4.0",`
-    : ''
-}
+      : ''
+  }
     "@types/node": "^20.11.30",
     "@types/chrome": "^0.0.263",
     "@types/react": "^18.2.69",


### PR DESCRIPTION
- [fix(cli): project gen name/path formatting](https://github.com/nyaggah/bedframe/commit/c5fddc2071de8f1e8a104a98e8101d596fa76979) 
ensure the different possible project name variations passed into prompts (as `name` `arg`s and/or `options.name`) are
formatted correctly
  - fixes https://github.com/nyaggah/bedframe/issues/453
- code clean up
